### PR TITLE
Fix Patch::to_string() referencing the wrong character.

### DIFF
--- a/diff_match_patch/src/dmp.rs
+++ b/diff_match_patch/src/dmp.rs
@@ -2817,7 +2817,7 @@ impl Patch {
                     }
                 }
                 if is {
-                    text.push(text_vec[i]);
+                    text.push(*text_vec_item);
                     continue;
                 }
                 else if *text_vec_item == '%' {


### PR DESCRIPTION
This change fixes an out-of-bounds access in Patch::to_string() that happens with the following example code:
```
            let mut data_a = String::from("bye abcd");
            let mut data_b = String::from("hello abcde ");
            let mut dmp = diff_match_patch::Dmp::new();
            let mut patches = dmp.patch_make1(&data_b, &data_a);
            let the_patch = dmp.patch_to_text(&mut patches);
```
