### PR TITLE
Skip reserved characters when representing lines as characters in diff_linemode

### DIFF
--- a/diff_match_patch/src/dmp.rs
+++ b/diff_match_patch/src/dmp.rs
@@ -817,18 +817,25 @@ impl Dmp {
                 }
             }
             else {
-                if linearray.len() == 1_114_111 {
-                    // Bail out at 1114111 because chr(1114112) throws.
+                let mut u32char = linearray.len() as i32;
+
+                // skip reserved range - U+D800 to U+DFFF
+                // unicode code points in this range can't be converted to unicode scalars
+                if u32char >= 55296 {
+                    u32char += 2048;
+                }
+
+                // 1114111 is the biggest unicode scalar, so stop here
+                if u32char == 1114111 {
                     line = text[(line_start as usize)..].iter().collect();
                     line_end = text.len() as i32 - 1;
                 }
-                line_start = line_end + 1;
+
                 linearray.push(line.clone());
-                linehash.insert(line.clone(), linearray.len() as i32 - 1);
-                if let Some(char1) = char::from_u32(linehash[&line] as u32) {
-                    chars.push(char1);
-                    line_start = line_end + 1;
-                }
+                linehash.insert(line.clone(), u32char);
+
+                chars.push(char::from_u32(u32char as u32).unwrap());
+                line_start = line_end + 1;
             }
         }
         chars

--- a/diff_match_patch/tests/integration_test.rs
+++ b/diff_match_patch/tests/integration_test.rs
@@ -144,14 +144,7 @@ pub fn test_diff_chars_tolines() {
     let mut char_list: Vec<char> = vec![];
     for i in 1..n + 1 {
         line_list.push(i.to_string() + "\n");
-        match char::from_u32(i) {
-            Some(ch) => {
-                char_list.push(ch);
-            }
-            None => {
-
-            }
-        }
+        char_list.push(char::from_u32(i).unwrap());
     }
     let chars: String = char_list.into_iter().collect();
     assert_eq!(n as usize, line_list.len());
@@ -161,6 +154,7 @@ pub fn test_diff_chars_tolines() {
     let mut diffs = vec![diff_match_patch::Diff::new(-1, chars)];
     dmp.diff_chars_tolines(&mut diffs, &line_list);
     assert_eq!(diffs, vec![diff_match_patch::Diff::new(-1, lines)]);
+
     // line_list = vec![];
     // for i in 1..1115000 + 1 {
     //     line_list.push(i.to_string() + "\n");
@@ -173,7 +167,29 @@ pub fn test_diff_chars_tolines() {
     // assert_eq!(chars, diffs[0].text);
 }
 
+#[test]
+pub fn diff_lines_tochars_munge() {
+    let mut dmp = diff_match_patch::Dmp::new();
 
+    // Unicode codepoints from 55296 to 57344 are reserved and can't be used as a scalar
+    let number_of_lines = 60000;
+
+    let mut text: Vec<char> = Vec::with_capacity(number_of_lines);
+    for i in 0..=number_of_lines {
+        text.extend(i.to_string().chars());
+        if i + 1 < number_of_lines {
+            text.extend("\n".chars());
+        }
+    }
+
+    let mut linearray: Vec<String> = vec!["".to_string()];
+    let mut linehash: HashMap<String, i32> = HashMap::new();
+    let chars1 = dmp.diff_lines_tochars_munge(&text, &mut linearray, &mut linehash);
+
+    assert_eq!(chars1.chars().count(), number_of_lines);
+    assert_eq!(linearray.len() - 1, number_of_lines);
+    assert_eq!(linehash.len(), number_of_lines);
+}
 
 #[test]
 pub fn test_diff_cleanup_merge() {


### PR DESCRIPTION
In Rust char represents a unicode scalar, which can be any unicode code point, except code points reserved for surrogates (http://www.unicode.org/glossary/#unicode_scalar_value).

Trying to create a char from a code point in reserved range results in an error. Currently the code ignores the error and skips the character, which can result in wrong diffs for texts with large number of lines.

In this PR I'm skipping the reserved code points range when representing lines as characters in diff_lines_tochars_munge.