### PR TITLE
Decode and encode delta using different length units

### DIFF
--- a/diff_match_patch/Cargo.lock
+++ b/diff_match_patch/Cargo.lock
@@ -4,114 +4,112 @@
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "diff_match_patch"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
- "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex",
+ "url",
 ]
 
 [[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "regex"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
- "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 
 [[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 dependencies = [
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
 ]
 
 [[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna",
+ "matches",
+ "percent-encoding",
 ]
-
-[metadata]
-"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
-"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
-"checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
-"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"

--- a/diff_match_patch/Cargo.toml
+++ b/diff_match_patch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diff_match_patch"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["chandan <chandanmahi1998@gmail.com>"]
 edition = "2018"
 description = "Diff Match Patch is a high-performance library in Rust-lang that manipulates plain text."
@@ -14,7 +14,3 @@ license = "MIT"
 [dependencies]
 url = "1.7.2"
 regex = "1.3.7"
-
-[[bin]]
-name = "main"
-path = "src/main.rs"

--- a/diff_match_patch/src/dmp.rs
+++ b/diff_match_patch/src/dmp.rs
@@ -8,8 +8,12 @@ use std::fmt;
 use core::char;
 use std::iter::FromIterator;
 use std::collections::HashMap;
+use std::result::Result;
+use std::error::Error;
 use regex::Regex;
 extern crate  url;
+
+use super::percent_encoding::percent_decode_u16;
 
 use url::percent_encoding::{
     utf8_percent_encode,
@@ -17,6 +21,14 @@ use url::percent_encoding::{
     DEFAULT_ENCODE_SET,
     USERINFO_ENCODE_SET,
     };
+
+pub enum LengthUnit {
+    #[allow(dead_code)]
+    UnicodeScalar,
+    #[allow(dead_code)]
+    UTF16
+}
+
 #[allow(dead_code)]
 pub struct Dmp {
     pub text1: String,
@@ -147,10 +159,56 @@ impl fmt::Debug for Patch {
     }
 }
 
+trait StringView {
+    fn len(&self) -> usize;
+    fn slice(&self, range: std::ops::Range<usize>) -> Result<String, std::string::FromUtf16Error>;
+}
 
+struct StringScalarView {
+    text: Vec<char>
+}
 
+impl StringScalarView {
+    #[allow(dead_code)]
+    pub fn new(text: &str) -> StringScalarView {
+        StringScalarView {
+            text: text.chars().collect()
+        }
+    } 
+}
 
+impl StringView for StringScalarView {
+    fn len(&self) -> usize {
+        self.text.len()
+    }
 
+    fn slice(&self, range: std::ops::Range<usize>) -> Result<String, std::string::FromUtf16Error> {
+        Ok((&self.text)[range].iter().collect())
+    }
+}
+
+struct StringUTF16View {
+    text: Vec<u16>
+}
+
+impl StringUTF16View {
+    #[allow(dead_code)]
+    pub fn new(text: &str) -> StringUTF16View {
+        StringUTF16View {
+            text: text.encode_utf16().collect()
+        }
+    }
+}
+
+impl StringView for StringUTF16View {
+    fn len(&self) -> usize {
+        self.text.len()
+    }
+
+    fn slice(&self, range: std::ops::Range<usize>) -> Result<String, std::string::FromUtf16Error> {
+        String::from_utf16(&self.text[range])
+    }
+}
 
 
 
@@ -1742,6 +1800,56 @@ impl Dmp {
         }
         text
     }
+    
+    pub fn diff_text2_from_delta_u16(&self, text1: &str, delta: &str) -> String {
+        /*
+        Compute and return the destination text (all equalities and insertions).
+        Delta offsets are interpreted in u16 code units
+
+        Args:
+            text1: Original text
+            delta: Text delta
+
+        Returns:
+            Destination text
+        */
+
+        let text1_u16: Vec<u16> = text1.encode_utf16().collect();
+        let mut text2_u16: Vec<u16> = Vec::new();
+
+        let tokens: Vec<&str> = (*delta).split('\t').collect();
+
+        let mut text_offset = 0;
+        for token in tokens {
+            if token.is_empty() {
+                continue;
+            }
+
+            let operation = &token[0..1];
+            let operation_content = &token[1..];
+
+            if operation == "+" {
+                let decoded = percent_decode_u16(operation_content.as_bytes()).unwrap();
+                text2_u16.extend(decoded);
+            } else {
+                let content_length = operation_content.parse::<usize>().unwrap();
+
+                if operation == "=" {
+                    let range = text_offset..(content_length + text_offset);
+                    text2_u16.extend(&text1_u16[range]);
+                }
+
+                text_offset += content_length;
+            }
+        }
+
+        // we should have consumed all text
+        if text1_u16.len() != text_offset {
+            panic!("wrong patern or text");
+        }
+
+        String::from_utf16(&text2_u16).unwrap()
+    }
 
     #[allow(dead_code)]
     pub fn diff_levenshtein(&mut self, diffs: &Vec<Diff>) -> i32 {
@@ -1778,6 +1886,11 @@ impl Dmp {
 
     #[allow(dead_code)]
     pub fn diff_todelta(&mut self, diffs: &mut Vec<Diff>) -> String {
+        self.diff_todelta_unit(diffs, LengthUnit::UnicodeScalar)
+    }
+
+    #[allow(dead_code)]
+    pub fn diff_todelta_unit(&mut self, diffs: &mut Vec<Diff>, length_unit: LengthUnit) -> String {
         /*
         Crush the diff into an encoded string which describes the operations
         required to transform text1 into text2.
@@ -1786,25 +1899,27 @@ impl Dmp {
 
         Args:
             diffs: Vector of diff object.
+            length_unit: Unit of length. 
+                For example diff from "🅰🅱" -> "🅱" can have different delta:
+                * When operating on unicode scalars delta will be "-1\t=1"
+                * For UTF-16 delta will be "-2\t=2" 
 
         Returns:
             Delta text.
-      */
+        */
         let mut text: String = "".to_string();
         let len = diffs.len();
-        for (k, diffs_item) in diffs.iter().enumerate().take(len) {
+        for (k, diffs_item) in diffs.iter().enumerate() {
             if diffs_item.operation == 1 {
                 // High ascii will raise UnicodeDecodeError.  Use Unicode instead.
                 let temp5: Vec<char> = vec!['!', '~', '*', '(', ')', ';', '/', '?', ':', '@', '&', '=', '+', '$', ',', '#', ' ', '\''];
                 let temp4: Vec<char> = diffs_item.text.chars().collect();
                 text += "+";
-                let mut text1 = "".to_string();
                 for temp4_item in &temp4 {
                     let mut is = false;
                     for temp5_item in &temp5 {
                         if *temp5_item == *temp4_item {
                             text.push(*temp4_item);
-                            text1.push(*temp4_item);
                             is = true;
                             break;
                         }
@@ -1816,19 +1931,28 @@ impl Dmp {
                     temp6.push(*temp4_item);
                     temp6 = utf8_percent_encode(temp6.as_str(), USERINFO_ENCODE_SET).collect();
                     text += temp6.as_str();
-                    text1 += temp6.as_str();
                 }
             }
-            else if diffs_item.operation == -1 {
-                let temp4: String = utf8_percent_encode(diffs_item.text.chars().count().to_string().as_str(), DEFAULT_ENCODE_SET).collect();
-                text += "-";
-                text += temp4.as_str();
-            }
             else {
-                let temp4: String = utf8_percent_encode(diffs_item.text.chars().count().to_string().as_str(), DEFAULT_ENCODE_SET).collect();
-                text += "=";
-                text += temp4.as_str();
+                if diffs_item.operation == -1 {
+                    text += "-";
+                }
+                else {
+                    text += "=";
+                }
+
+                let count: usize;
+                match length_unit {
+                    LengthUnit::UnicodeScalar => {
+                        count = diffs_item.text.chars().count();
+                    },
+                    LengthUnit::UTF16 => {
+                        count = diffs_item.text.encode_utf16().count();
+                    },
+                }
+                text += count.to_string().as_str();
             }
+
             if k < len - 1 {
                 text += "\t";
             }
@@ -1838,6 +1962,11 @@ impl Dmp {
 
     #[allow(dead_code)]
     pub fn diff_from_delta(&mut self, text1: &str, delta: &str) -> Vec<Diff> {
+        self.diff_from_delta_unit(text1, delta, LengthUnit::UnicodeScalar)
+    }
+
+    #[allow(dead_code)]
+    pub fn diff_from_delta_unit(&mut self, text1: &str, delta: &str, length_unit: LengthUnit) -> Vec<Diff> {
         /*
         Given the original text1, and an encoded string which describes the
         operations required to transform text1 into text2, compute the full diff.
@@ -1845,54 +1974,69 @@ impl Dmp {
         Args:
             text1: Source string for the diff.
             delta: Delta text.
+            length_unit: Unit of length used in delta. 
 
         Returns:
             Vector of diff object.
 
         Raises:
             ValueError: If invalid input.
-      */
+        */
+
+        match length_unit {
+            LengthUnit::UnicodeScalar => {
+                let text = StringScalarView::new(text1);
+                return self.diff_from_delta_string_view(&text, delta).unwrap();
+            },
+            LengthUnit::UTF16 => {
+                let text = StringUTF16View::new(text1);
+                match self.diff_from_delta_string_view(&text, delta) {
+                    Ok(diff) => diff,
+                    Err(_) => {
+                        let text2 = self.diff_text2_from_delta_u16(&text1, &delta);
+                        self.diff_main(&text1, &text2, true)
+                    }
+                }
+            },
+        }
+    }
+
+    fn diff_from_delta_string_view(&self, text1: &impl StringView, delta: &str) -> Result<Vec<Diff>, Box<dyn Error>> {
         let mut diffs: Vec<Diff> = vec![];
         let tokens: Vec<&str> = (*delta).split('\t').collect();
-        let text1_vec: Vec<char> = text1.chars().collect();
-        let len = text1.chars().count();
-        let mut text_len = 0;
+
+        let mut text_offset = 0;
         for token in tokens {
-            if token =="" {
+            if token.is_empty() {
                 continue;
             }
-            let token_vec: Vec<char> = token.chars().collect();
-            let operation: String = (&token_vec)[0..1].iter().collect();
-            let text: String = (&token_vec)[1..].iter().collect();
-            let text2 = percent_decode(text.as_bytes()).decode_utf8().unwrap().to_string();
-            if operation.as_str() == "+" {
-                diffs.push(Diff::new(1, text2));
-            }
-            else if operation.as_str() == "=" {
-                let str_size = text2.as_str().parse::<i32>().unwrap();
-                if str_size as usize + text_len > len {
-                    panic!("wrong patern or text");
-                }
-                let temp8: String = (&text1_vec)[max(text_len as i32, 0) as usize..min(str_size + text_len as i32, text1_vec.len() as i32) as usize].iter().collect();
-                diffs.push(Diff::new(0, temp8));
-                text_len += str_size as usize;
-            }
-            else{
-                
-                let str_size = text2.as_str().parse::<i32>().unwrap();
-                if str_size as usize + text_len > len {
-                    panic!("wrong patern or text");
-                }
-                let temp8: String = (&text1_vec)[max(text_len as i32, 0)as usize..min(text1_vec.len() as i32, text_len as i32 + str_size as i32) as usize].iter().collect();
-                diffs.push(Diff::new(-1, temp8));
-                text_len += str_size as usize;
+            
+            let operation = &token[0..1];
+            let operation_content = &token[1..];
+
+            if operation == "+" {
+                let text = percent_decode(operation_content.as_bytes()).decode_utf8()?.to_string();
+                diffs.push(Diff::new(1, text));
+            } else {
+                let content_length = operation_content.parse::<usize>().unwrap();
+                let range = text_offset..(content_length + text_offset);
+
+                diffs.push(Diff::new(
+                    if operation == "=" { 0 } else { -1 }, 
+                    text1.slice(range)?
+                ));
+
+                text_offset += content_length;
             }
         }
-        if len != text_len {
+
+        // we should have consumed all text
+        if text1.len() != text_offset {
             panic!("wrong patern or text");
         }
-        diffs
-    } 
+
+        Ok(diffs)
+    }
 
     #[allow(dead_code)]
     pub fn match_main(&mut self, text1: &str, patern1: &str, mut loc: i32) -> i32 {

--- a/diff_match_patch/src/lib.rs
+++ b/diff_match_patch/src/lib.rs
@@ -1,3 +1,4 @@
 mod dmp;
+mod percent_encoding;
 
 pub use dmp::*;

--- a/diff_match_patch/src/main.rs
+++ b/diff_match_patch/src/main.rs
@@ -1,3 +1,0 @@
-mod dmp;
-fn main() {
-}

--- a/diff_match_patch/src/percent_encoding.rs
+++ b/diff_match_patch/src/percent_encoding.rs
@@ -1,0 +1,128 @@
+use std::fmt;
+
+ #[derive(Debug, Clone)]
+ pub struct DecodeError;
+ impl fmt::Display for DecodeError {
+     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+         write!(f, "Malformed string")
+     }
+ }
+ impl std::error::Error for DecodeError {}
+
+
+ pub fn percent_decode_u16(input: &[u8]) -> Result<Vec<u16>, Box<dyn std::error::Error>> {
+     let mut input_iter = input.iter();
+     let mut result: Vec<u16> = Vec::new();
+
+     while let Some(&byte) = input_iter.next() {
+         if byte != b'%' {
+             result.push(byte as u16);
+             continue;
+         }
+
+         let byte1 = next_percent_encoded_byte(&mut input_iter, true);
+         if (byte1 & 0x80) == 0 {
+             result.push(byte1);
+             continue;
+         }
+
+         let mut byte2 = next_percent_encoded_byte(&mut input_iter, false);
+         // continuation bytes have bitmask 10xx xxxx
+         if (byte2 & 0xC0) != 0x80 {
+             return Err(DecodeError.into());
+         }
+
+         // continuation bytes thus only contribute six bits each
+         // these data bits are found with the bit mask xx11 1111
+         byte2 = byte2 & 0x3F;
+
+         // in two-byte sequences the first byte has bitmask 110x xxxx
+         if (byte1 & 0xE0) == 0xC0 {
+             // byte1 ___x xxxx << 6
+             // byte2        __yy yyyy
+             // value    x xxxxyy yyyy -> 11 bits
+             result.push(((byte1 & 0x1F) << 6) | byte2);
+             continue;
+         }
+
+         let mut byte3 = next_percent_encoded_byte(&mut input_iter, false);
+         if (byte3 & 0xC0) != 0x80 {
+             return Err(DecodeError.into());
+         }
+
+         byte3 = byte3 & 0x3F;
+
+         // in three-byte sequences the first byte has bitmask 1110 xxxx
+         if (byte1 & 0xF0) == 0xE0 {
+             // byte1 ____ xxxx << 12
+             // byte2        __yy yyyy << 6
+             // byte3               __zz zzzz
+             // value      xxxxyy yyyyzz zzzz -> 16 bits
+             result.push(((byte1 & 0x0F) << 12) | (byte2 << 6) | byte3);
+             continue;
+         }
+
+         let mut byte4 = next_percent_encoded_byte(&mut input_iter, false);
+         if (byte4 & 0xC0) != 0x80 {
+             return Err(DecodeError.into());
+         }
+
+         byte4 = byte4 & 0x3F;
+
+         // in four-byte sequences the first byte has bitmask 1111 0xxx
+         if (byte1 & 0xF8) == 0xF0 {
+             // byte1 ____ _xxx << 18
+             // byte2        __yy yyyy << 12
+             // byte3               __zz zzzz << 6
+             // byte4                      __tt tttt
+             // value       xxxyy yyyyzz zzzztt tttt -> 21 bits
+             let mut code_point = ((byte1 as u32 & 0x07) << 0x12) | ((byte2 as u32) << 0x0C) | ((byte3 as u32) << 0x06) | byte4 as u32;
+             if code_point >= 0x010000 && code_point <= 0x10FFFF {
+                 code_point -= 0x010000;
+
+                 result.push((((code_point >> 10) & 0x3FF) | 0xD800) as u16);
+                 result.push((0xDC00 | (code_point & 0x3FF)) as u16);
+                 continue;
+             }
+         }
+
+         return Err(DecodeError.into());
+     }
+
+     Ok(result)
+ }
+
+ fn next_percent_encoded_byte(iter: &mut std::slice::Iter<u8>, skip_percent: bool) -> u16 {
+     if !skip_percent && iter.next() != Some(&b'%') {
+         panic!("URI malformed");
+     }
+
+     let h = iter.next().and_then(|&b| (b as char).to_digit(16)).unwrap();
+     let l = iter.next().and_then(|&b| (b as char).to_digit(16)).unwrap();
+
+     (h as u8 * 0x10 + l as u8) as u16
+ }
+
+ #[cfg(test)]
+ mod tests {
+     use super::*;
+
+     #[test]
+     fn test_decode_full_surrogate_pair() {
+         let result = percent_decode_u16("%F0%9F%85%B1".as_bytes());
+         assert_eq!(result.unwrap(), vec![55356, 56689]);
+     }
+
+     #[test]
+     fn test_decode_half_surrogate_pair() {
+         let result = percent_decode_u16("%ED%B5%B1".as_bytes());
+         assert_eq!(result.unwrap(), vec![56689]);
+     }
+
+     #[test]
+     fn test_decode_keeps_non_percent_encoded_data() {
+         let result = percent_decode_u16("123%ED%B5%B1".as_bytes());
+         assert_eq!(result.unwrap(), vec![49, 50, 51, 56689]);
+     }
+ }
+ 


### PR DESCRIPTION
What is the length of "🅰"? Well, it depends...
* if counting using Unicode Scalar Values (or char in rust), it is `1`
* if counting using UTF-16 code points, it is `2` (it is a surrogate pair)

Most diff-match-patch libraries use UTF-16 under the hood to represent strings which brings the compatibility issue of using deltas generating by one library in another library.

For example, running a diff "🅰🅱" -> "🅱" in python will produce the following delta: `-2\t=2`, but this library operates on scalar values, which makes it impossible to interpret this delta. Delta produced by this library would be `-1\t=1`.

To make things more complex libraries that perform diff on UTF-16 encoded strings sometimes split surrogate pairs, which may result in invalid string.

For example, running a diff "🅰" -> "🅱". In UTF16 it is "0xD83C 0xDD70" -> "0xD83C 0xDD71", the difference is only the second code point and percent encoded delta is `=1\t-1\t+%ED%B5%B1`. It splits the surrogate pair and parts of surrogate pair on their own are not valid unicode scalars.

In this PR:
* `percent_decode_u16` method performs a custom forgiving percent decoding keeping split surrogate pairs. Percent encoding from the library throws an error because part of a surrogate pair is not a valid character.
* there is a new version of `diff_todelta` and `diff_from_delta` that accept `LengthUnit` and try to encode/decode delta using specified unit.
* when `diff_from_delta` runs in UTF-16 mode and string decode fails, it will make an additional attempt to recover destination string and if successful to run a new diff.

It would be awesome if other libraries also operate on unicode scalar values like this one, but unfortunately they are not.

p.s. sorry for spamming you with PRs 🙇 