### PR TITLE
Fix index out of bounds crash in patch_apply

### DIFF
--- a/diff_match_patch/tests/integration_test.rs
+++ b/diff_match_patch/tests/integration_test.rs
@@ -1026,4 +1026,9 @@ pub fn test_patch_apply() {
     patches = dmp.patch_make1("y", "y123");
     results = dmp.patch_apply(&mut patches, "x");
     assert_eq!(("x123".chars().collect(), vec![true]), results);
+
+    // Applying "delete" patch on an empty text.
+    patches = dmp.patch_make1("test", "");
+    results = dmp.patch_apply(&mut patches, "");
+    assert_eq!(("".chars().collect(), vec![true]), results);
 }


### PR DESCRIPTION
I found that in certain cases applying a patch results in an "out of bounds" crash.

Pseudocode crash example: 
```
patches = patch_make("test", "")
patch_apply(patches, "")
```

The fix is to cap the end index so that it stays below the length of collection.

Example of how it is done in Java: https://github.com/google/diff-match-patch/blob/master/java/src/name/fraser/neil/plaintext/diff_match_patch.java#L1979